### PR TITLE
Added options for custom line endings and outlook import; plus small bugfix

### DIFF
--- a/index.php
+++ b/index.php
@@ -66,7 +66,7 @@ if (!empty($_FILES['_vcards']))
 	// parse the vCard file
 	else if ($conv->fromFile($_FILES['_vcards']['tmp_name']))
 	{
-		$ext = $_POST['_format'] == 'gmail' ? 'csv' : ($_POST['_format'] == 'img' ? 'zip' : $_POST['_format']);
+		$ext = ($_POST['_format'] == 'gmail' || $_POST['_format'] == 'outlook_de') ? 'csv' : ($_POST['_format'] == 'img' ? 'zip' : $_POST['_format']);
 		$fname = asciiwords(preg_replace('/\.[a-z]+$/i', '', $_FILES['_vcards']['name']));
 
 		header(sprintf('Content-Type: text/%s', $ext));
@@ -92,6 +92,11 @@ if (!empty($_FILES['_vcards']))
 		else if ($_POST['_format'] == 'fritzbox')
 		{
 			print $conv->toFritzBox();
+			exit;
+		}
+		else if ($_POST['_format'] == 'outlook_de')
+		{
+			print $conv->toCSV(',', "\r\n", true, 'ISO-8859-15', 'de_outlook');
 			exit;
 		}
 		else if ($_POST['_format'] == 'csv')

--- a/index.php
+++ b/index.php
@@ -55,7 +55,7 @@ if (!empty($_FILES['_vcards']))
 		'phoneonly' => !empty($_POST['_phoneonly']),
 		'accesscode' => preg_replace('/[^1-9]/', '', $_POST['_accesscode']),
 	));
-	
+
 	// check for errors
 	if ($err = $_FILES['_vcards']['error'])
 	{
@@ -88,17 +88,23 @@ if (!empty($_FILES['_vcards']))
 		{
 			print $conv->toGmail();
 			exit;
-		}	
+		}
 		else if ($_POST['_format'] == 'fritzbox')
 		{
 			print $conv->toFritzBox();
 			exit;
-		}	
+		}
 		else if ($_POST['_format'] == 'csv')
 		{
 			$header = $_POST['_header'] === '1' ? true : false;
 			$delimiter = $_POST['_delimiter'] == 'tab' ? "\t" : $_POST['_delimiter'];
-			print $conv->toCSV($delimiter, $header, $_POST['_encoding']);
+			$eol_marker = array(
+				'unix' => "\n",
+				'dos' => "\r\n",
+				'mac' => "\r",
+			);
+			$eol_marker = $eol_marker[$_POST['_eol_marker']];
+			print $conv->toCSV($delimiter, $eol_marker, $header, $_POST['_encoding']);
 			exit;
 		}
 		// extract all images from the vcard file
@@ -124,7 +130,7 @@ if (!empty($_FILES['_vcards']))
 			}
 
 			shell_exec('rm -rf '.escapeshellarg($tmpdir));
-			
+
 			if ($success)
 				exit;
 		}

--- a/page.html
+++ b/page.html
@@ -105,6 +105,18 @@ function set_form_fields(elem)
       encoding.disabled = true;
       dn.disabled = true;
       break;
+      
+    case 'outlook_de':
+        encoding.selectedIndex = 2;
+        delimiter.selectedIndex = 2;
+        eol_marker.selectedIndex = 1;
+        header.checked = true;
+        header.disabled = true;
+        delimiter.disabled = true;
+        eol_marker.disabled = true;
+        encoding.disabled = true;
+        dn.disabled = true;
+        break;
   }
 
   var rootdnrow = document.getElementById('ldaprootdn');
@@ -149,6 +161,7 @@ if (!empty($GLOBALS['error_msg']))
   <option value="csv">CSV</option>
   <option value="gmail">Gmail (CSV)</option>
   <option value="fritzbox">FritzBox (CSV)</option>
+  <option value="outlook_de">Outlook (German CSV)</option>
   <option value="img">Images</option>
 </select>
 <select name="_delimiter" disabled>

--- a/page.html
+++ b/page.html
@@ -60,6 +60,7 @@ function set_form_fields(elem)
   var format = elem.options[elem.selectedIndex].value;
   var header = elem.form._header;
   var delimiter = elem.form._delimiter;
+  var eol_marker = elem.form._eol_marker;
   var encoding = elem.form._encoding;
   var dn = elem.form._dn;
 
@@ -72,6 +73,7 @@ function set_form_fields(elem)
     case 'img':
       header.disabled = true;
       delimiter.disabled = true;
+      eol_marker.disabled = true;
       encoding.disabled = true;
       dn.disabled = true;
       break;
@@ -79,6 +81,7 @@ function set_form_fields(elem)
     case 'ldap':
       header.disabled = true;
       delimiter.disabled = true;
+      eol_marker.disabled = true;
       encoding.disabled = false;
       dn.disabled = false;
       break;
@@ -86,6 +89,7 @@ function set_form_fields(elem)
     case 'csv':
       header.disabled = false;
       delimiter.disabled = false;
+      eol_marker.disabled = false;
       encoding.disabled = false;
       dn.disabled = true;
       break;
@@ -93,9 +97,11 @@ function set_form_fields(elem)
     case 'fritzbox':
       encoding.selectedIndex = 1;
       delimiter.selectedIndex = 1;
+      eol_marker.selectedIndex = 0;
       header.checked = true;
       header.disabled = true;
       delimiter.disabled = true;
+      eol_marker.disabled = true;
       encoding.disabled = true;
       dn.disabled = true;
       break;
@@ -149,6 +155,11 @@ if (!empty($GLOBALS['error_msg']))
   <option value="tab">Tab</option>
   <option value=";">Semicolon</option>
   <option value=",">Comma</option>
+</select>
+<select name="_eol_marker" disabled>
+  <option value="unix">Unix (CRLF)</option>
+  <option value="dos">DOS/Windows (LF)</option>
+  <option value="mac">Old Mac (pre-OSX, CR)</option>
 </select>
 <input type="checkbox" name="_header" id="checkHeader" value="1" disabled><label for="checkHeader">&nbsp;Add header line</label></td>
 

--- a/page.html
+++ b/page.html
@@ -157,8 +157,8 @@ if (!empty($GLOBALS['error_msg']))
   <option value=",">Comma</option>
 </select>
 <select name="_eol_marker" disabled>
-  <option value="unix">Unix (CRLF)</option>
-  <option value="dos">DOS/Windows (LF)</option>
+  <option value="unix">Unix (LF)</option>
+  <option value="dos">DOS/Windows (CRLF)</option>
   <option value="mac">Old Mac (pre-OSX, CR)</option>
 </select>
 <input type="checkbox" name="_header" id="checkHeader" value="1" disabled><label for="checkHeader">&nbsp;Add header line</label></td>

--- a/vcard_convert.php
+++ b/vcard_convert.php
@@ -424,7 +424,7 @@ class vcard_convert extends Contact_Vcard_Parse
 			$out .= 'Home Phone'.$delm.'Business Phone'.$delm.'Home Fax'.$delm.'Business Fax'.$delm.'Pager'.$delm.'Mobile Phone'.$delm;
 			$out .= 'Home Street'.$delm.'Home Address 2'.$delm.'Home City'.$delm.'Home State'.$delm.'Home Postal Code'.$delm.'Home Country'.$delm;
 			$out .= 'Business Address'.$delm.'Business Address 2'.$delm.'Business City'.$delm.'Business State'.$delm.'Business Postal Code'.$delm;
-			$out .= 'Business Country'.$delm.'Country Code'.$delm.'Related name'.$delm.'Job Title'.$delm.'Department'.$delm.'Organization'.$delm.'Notes'.$delm.
+			$out .= 'Business Country'.$delm.'Country Code'.$delm.'Related name'.$delm.'Job Title'.$delm.'Department'.$delm.'Organization'.$delm.'Notes'.$delm;
 			$out .= 'Birthday'.$delm.'Anniversary'.$delm.'Gender'.$delm;
 			$out .= 'Web Page'.$delm.'Web Page 2'.$delm.'Categories'.$eolm;
 		}

--- a/vcard_convert.php
+++ b/vcard_convert.php
@@ -413,20 +413,33 @@ class vcard_convert extends Contact_Vcard_Parse
 	/**
 	 * Convert the parsed vCard data into CSV format
 	 */
-	function toCSV($delm="\t", $eolm="\n", $add_title=true, $encoding=null)
+	function toCSV($delm="\t", $eolm="\n", $add_title=true, $encoding=null, $title_type='en')
 		{
 		$out = '';
 		$this->export_count = 0;
 
 		if ($add_title)
 		{
-			$out .= 'First Name'.$delm.'Last Name'.$delm.'Display Name'.$delm.'Nickname'.$delm.'E-mail Address'.$delm.'E-mail 2 Address'.$delm.'E-mail 3 Address'.$delm;
-			$out .= 'Home Phone'.$delm.'Business Phone'.$delm.'Home Fax'.$delm.'Business Fax'.$delm.'Pager'.$delm.'Mobile Phone'.$delm;
-			$out .= 'Home Street'.$delm.'Home Address 2'.$delm.'Home City'.$delm.'Home State'.$delm.'Home Postal Code'.$delm.'Home Country'.$delm;
-			$out .= 'Business Address'.$delm.'Business Address 2'.$delm.'Business City'.$delm.'Business State'.$delm.'Business Postal Code'.$delm;
-			$out .= 'Business Country'.$delm.'Country Code'.$delm.'Related name'.$delm.'Job Title'.$delm.'Department'.$delm.'Organization'.$delm.'Notes'.$delm;
-			$out .= 'Birthday'.$delm.'Anniversary'.$delm.'Gender'.$delm;
-			$out .= 'Web Page'.$delm.'Web Page 2'.$delm.'Categories'.$eolm;
+			if ('de_outlook' == $title_type)
+			{
+				$out .= 'Vorname'.$delm.'Nachname'.$delm.'Name'.$delm.'Spitzname'.$delm.'E-Mail'.$delm.'E-Mail 2'.$delm.'E-Mail 3'.$delm;
+				$out .= 'Telefon privat'.$delm.'Telefon geschäftlich'.$delm.'Fax privat'.$delm.'Fax geschäftlich'.$delm.'Pager'.$delm.'Mobiltelefon'.$delm;
+				$out .= 'Straße privat'.$delm.'Straße privat 2'.$delm.'Ort privat'.$delm.'Bundesland/Kanton privat'.$delm.'Postleitzahl privat'.$delm.'Land/Region privat'.$delm;
+				$out .= 'Straße geschäftlich'.$delm.'Straße geschäftlich 2'.$delm.'Ort geschäftlich'.$delm.'Region geschäftlich'.$delm.'Postleitzahl geschäftlich'.$delm;
+				$out .= 'Land/Region geschäftlich'.$delm.'Landescode'.$delm.'Partner'.$delm.'Position'.$delm.'Abteilung'.$delm.'Firma'.$delm.'Notizen'.$delm;
+				$out .= 'Geburtstag'.$delm.'Jahrestag'.$delm.'Geschlecht'.$delm;
+				$out .= 'Webseite'.$delm.'Webseite 2'.$delm.'Kategorien'.$eolm;
+			}
+			else
+			{
+				$out .= 'First Name'.$delm.'Last Name'.$delm.'Display Name'.$delm.'Nickname'.$delm.'E-mail Address'.$delm.'E-mail 2 Address'.$delm.'E-mail 3 Address'.$delm;
+				$out .= 'Home Phone'.$delm.'Business Phone'.$delm.'Home Fax'.$delm.'Business Fax'.$delm.'Pager'.$delm.'Mobile Phone'.$delm;
+				$out .= 'Home Street'.$delm.'Home Address 2'.$delm.'Home City'.$delm.'Home State'.$delm.'Home Postal Code'.$delm.'Home Country'.$delm;
+				$out .= 'Business Address'.$delm.'Business Address 2'.$delm.'Business City'.$delm.'Business State'.$delm.'Business Postal Code'.$delm;
+				$out .= 'Business Country'.$delm.'Country Code'.$delm.'Related name'.$delm.'Job Title'.$delm.'Department'.$delm.'Organization'.$delm.'Notes'.$delm;
+				$out .= 'Birthday'.$delm.'Anniversary'.$delm.'Gender'.$delm;
+				$out .= 'Web Page'.$delm.'Web Page 2'.$delm.'Categories'.$eolm;
+			}
 		}
 
 		foreach ($this->cards as $card)

--- a/vcard_convert.php
+++ b/vcard_convert.php
@@ -64,8 +64,8 @@ class vcard_convert extends Contact_Vcard_Parse
 	var $mailonly = false;
 	var $phoneonly = false;
 	var $accesscode = null;
-	
-	
+
+
 	/**
 	 * Constructor taking a list of converter properties
 	 */
@@ -89,7 +89,7 @@ class vcard_convert extends Contact_Vcard_Parse
 		// dump to, and get return from, the fromText() method.
 		return $this->fromText($text, $decode_qp);
 	}
-	
+
 	/**
 	 * Parse a given string for vCards
 	 *
@@ -115,18 +115,18 @@ class vcard_convert extends Contact_Vcard_Parse
 		if (!empty($this->parsed))
 		{
 			$this->normalize();
-			
+
 			// after normalize() all values should be UTF-8
 			if (!isset($this->charset))
 				$this->charset = 'UTF-8';
-				
+
 			return count($this->cards);
 		}
 		else
 			return false;
 	}
-	
-	
+
+
 	/**
 	 * Convert the abstract vCard structure into address objects
 	 *
@@ -139,7 +139,7 @@ class vcard_convert extends Contact_Vcard_Parse
 		{
 			$vcard = new vCard;
 			$vcard->version = (float)$card['VERSION'][0]['value'][0][0];
-			
+
 			// convert all values to UTF-8 according to their charset param
 			if (!isset($this->charset))
 				$card = $this->card2utf8($card);
@@ -150,7 +150,7 @@ class vcard_convert extends Contact_Vcard_Parse
 			$vcard->firstname = trim($names[1][0]);
 			$vcard->middlename = trim($names[2][0]);
 			$vcard->title = trim($names[3][0]);
-			
+
 			if (empty($vcard->title) && isset($card['TITLE']))
 				$vcard->title = trim($card['TITLE'][0]['value'][0][0]);
 
@@ -195,7 +195,7 @@ class vcard_convert extends Contact_Vcard_Parse
 				$vcard->organization = trim($temp[0][0]);
 				$vcard->department   = trim($temp[1][0]);
 			}
-			
+
 			// extract urls
 			if (is_array($card['URL']))
 				$this->parse_url($card['URL'], $vcard);
@@ -255,7 +255,7 @@ class vcard_convert extends Contact_Vcard_Parse
 				$vcard->email2 = $a_email[1];
 			if (!empty($a_email[2]))
 				$vcard->email3 = $a_email[2];
-			
+
 			// find IM entries
 			if (is_array($card['X-AIM']))
 				$vcard->im['aim'] = $card['X-AIM'][0]['value'][0][0];
@@ -333,7 +333,7 @@ class vcard_convert extends Contact_Vcard_Parse
 			if (in_array_nc("WORK", $adr['param']['TYPE']))
 				$work = $adr['value'];
 		}
-		
+
 		// values not splitted by Contact_Vcard_Parse if key is like item1.ADR
 		if (strstr($home[0][0], ';'))
 		{
@@ -354,7 +354,7 @@ class vcard_convert extends Contact_Vcard_Parse
 				'zipcode' => $home[5][0],
 				'country' => $home[6][0]);
 		}
-		
+
 		// values not splitted by Contact_Vcard_Parse if key is like item1.ADR
 		if (strstr($work[0][0], ';'))
 		{
@@ -408,12 +408,12 @@ class vcard_convert extends Contact_Vcard_Parse
 			}
 		}
 	}
-	
+
 
 	/**
 	 * Convert the parsed vCard data into CSV format
 	 */
-	function toCSV($delm="\t", $add_title=true, $encoding=null)
+	function toCSV($delm="\t", $eolm="\n", $add_title=true, $encoding=null)
 		{
 		$out = '';
 		$this->export_count = 0;
@@ -426,7 +426,7 @@ class vcard_convert extends Contact_Vcard_Parse
 			$out .= 'Business Address'.$delm.'Business Address 2'.$delm.'Business City'.$delm.'Business State'.$delm.'Business Postal Code'.$delm;
 			$out .= 'Business Country'.$delm.'Country Code'.$delm.'Related name'.$delm.'Job Title'.$delm.'Department'.$delm.'Organization'.$delm.'Notes'.$delm.
 			$out .= 'Birthday'.$delm.'Anniversary'.$delm.'Gender'.$delm;
-			$out .= 'Web Page'.$delm.'Web Page 2'.$delm.'Categories'."\n";
+			$out .= 'Web Page'.$delm.'Web Page 2'.$delm.'Categories'.$eolm;
 		}
 
 		foreach ($this->cards as $card)
@@ -474,13 +474,13 @@ class vcard_convert extends Contact_Vcard_Parse
 			$out .= $this->csv_encode($card->home['url'], $delm);
 			$out .= $this->csv_encode($card->categories, $delm, false);
 
-			$out .= "\n";
+			$out .= $eolm;
 			$this->export_count++;
 		}
 
 		return $this->charset_convert($out, $encoding);
 	}
-	
+
 	/**
 	 * New GMail export function
 	 *
@@ -516,7 +516,7 @@ class vcard_convert extends Contact_Vcard_Parse
 			if ($card->work['state']) $work[] = $card->work['state'];
 			if ($card->work['zipcode']) $work[] = $card->work['zipcode'];
 			if ($card->work['country']) $work[] = $card->work['country'];
-			
+
 			$im = array_values($card->im);
 
 			$out .= $this->csv_encode($card->displayname, $delm);
@@ -657,17 +657,17 @@ class vcard_convert extends Contact_Vcard_Parse
 			}
 
 			$a_out = array();
-			
+
 			if ($identifier == "")
 				$a_out['dn'] = sprintf("cn=%s,mail=%s", $card->displayname, $card->email);
 			else
 				$a_out['dn'] = sprintf("uid=%s, %s", $card->uid, $identifier);
-				
+
 			$a_out['objectclass'] = array('top', 'person', 'organizationalPerson', 'inetOrgPerson', 'mozillaAbPerson');
 
 			$a_out['cn'] = $card->displayname;
 			$a_out['sn'] = $card->surname;
-			
+
 			if ($card->uid)
 				$a_out['uid'] = $card->uid;
 			if ($card->firstname)
@@ -764,7 +764,7 @@ class vcard_convert extends Contact_Vcard_Parse
 		$delm=";";
 		$out = 'sep='.$delm."\r\n";
 		$this->export_count = 0;
-		
+
 		$out .= 'Name'.$delm.
 				'TelNumHome'.$delm.'VanityHome'.$delm.'KurzWahlHome'.$delm.
 				'TelNumWork'.$delm.'VanityWork'.$delm.'KurzWahlWork'.$delm.
@@ -779,12 +779,12 @@ class vcard_convert extends Contact_Vcard_Parse
 				continue;
 			if ($this->phoneonly && empty($card->home['phone']) && empty($card->work['phone']) && empty($card->mobile))
 				continue;
-			
+
 			$name=array();
 			$firstname    = $this->csv_encode($card->firstname, $delm, false);
 			$surname      = $this->csv_encode($card->surname, $delm, false);
 			$organization = $this->csv_encode($card->organization, $delm, false);
-			
+
 			if (strlen($surname))   $name[] = $surname;
 			if (strlen($firstname)) $name[] = $firstname;
 			if (count($name))
@@ -794,19 +794,19 @@ class vcard_convert extends Contact_Vcard_Parse
 			{
 				$out .= $organization.$delm;
 			}
-			
+
 			$out .= $this->csv_encode($this->normalize_phone($card->home['phone']), $delm);
-			$out .= $delm; # Vanity			
-			$out .= $delm; # Kurzwahl			
+			$out .= $delm; # Vanity
+			$out .= $delm; # Kurzwahl
 			$out .= $this->csv_encode($this->normalize_phone($card->work['phone']), $delm);
-			$out .= $delm; # Vanity			
-			$out .= $delm; # Kurzwahl			
+			$out .= $delm; # Vanity
+			$out .= $delm; # Kurzwahl
 			$out .= $this->csv_encode($this->normalize_phone($card->mobile), $delm);
-			$out .= $delm; # Vanity			
-			$out .= $delm; # Kurzwahl			
+			$out .= $delm; # Vanity
+			$out .= $delm; # Kurzwahl
 			$out .= $this->csv_encode($card->notes, $delm);
 			$out .= $organization.$delm;
-			$out .= $delm; # Bild			
+			$out .= $delm; # Bild
 			$out .= $delm; # Kategorie
 			$out .= $delm; # ImageUrl
 			$out .= '1'.$delm; #Prio
@@ -824,14 +824,14 @@ class vcard_convert extends Contact_Vcard_Parse
 
 		return $out;
 	}
-	
+
 	/**
 	 * Export all cards images
 	 */
 	function toImages($tmpdir)
 	{
 		$this->export_count = 0;
-		
+
 		foreach($this->cards as $card)
 		{
 			if ($card->photo)
@@ -841,10 +841,10 @@ class vcard_convert extends Contact_Vcard_Parse
 				{
 					if ($ext == "jpeg")
 						$ext = "jpg";
-					
+
 					// Try to guess the displayname of the card if it is empty
 					$card->displayname = trim($card->displayname);
-				
+
 					if (empty($card->displayname))
 						$card->displayname = trim($card->firstname.' '.$card->surname);
 					if (empty($card->displayname))
@@ -882,8 +882,8 @@ class vcard_convert extends Contact_Vcard_Parse
 			$str = '"'.$str.'"';
 		return preg_replace('/\r?\n/', ' ', $str) . ($add_delm ? $delm : '');
 	}
-	
-	
+
+
 	/**
 	 * Encode one col string for Ldif export
 	 *
@@ -914,8 +914,8 @@ class vcard_convert extends Contact_Vcard_Parse
 			$phone = preg_replace('/^[\+|00]+' . $this->accesscode . '[- ]*(\d+)/', '0\1', $phone);
 		return $phone;
 	}
-	
-	
+
+
 	/**
 	 * Convert a whole vcard (array) to UTF-8.
 	 * Each member value that has a charset parameter will be converted.
@@ -935,7 +935,7 @@ class vcard_convert extends Contact_Vcard_Parse
 				}
 			}
 		}
-		
+
 		return $card;
 	}
 
@@ -949,10 +949,10 @@ class vcard_convert extends Contact_Vcard_Parse
 	{
 		// Sometimes the charset in $from is in quotes, so clean it up
 		$from = trim($from,'"');
-		
+
 		if (!$from)
 			$from = $this->charset;
-		
+
 		// recursively convert all array values
 		if (is_array($in))
 		{
@@ -1054,7 +1054,7 @@ class vcard_convert extends Contact_Vcard_Parse
 			| \xF4[\x80-\x8F][\x80-\xBF]{2}
 			)*\z/xs', substr($string, 0, 2048));
 	}
-	
+
 }  // end class vcard_convert
 
 

--- a/vcfconvert.sh
+++ b/vcfconvert.sh
@@ -50,7 +50,7 @@ function get_args()
 $opt = get_args();
 $usage = <<<EOF
 Usage: convert [-himpv] [-d delimiter] [-n identifier] [-o output_file] -f format file
-  -f Target format (ldif,ldap,csv,gmail,libdlusb)
+  -f Target format (ldif,ldap,csv,gmail,outlook_de,libdlusb)
   -n LDAP identifier added to dn:
   -o Output file (write to stdout by default)
   -d CSV col delimiter
@@ -102,6 +102,9 @@ if ($conv->fromFile($file))
 
 		else if ($format == 'fritzbox')
 			$out = $conv->toFritzBox();
+
+		else if ($format == 'outlook_de')
+			$out = $conv->toCSV(',', "\r\n", true, 'ISO-8859-15', 'de_outlook'); 
 			
 		else if ($format == 'csv')
 		{

--- a/vcfconvert.sh
+++ b/vcfconvert.sh
@@ -54,6 +54,7 @@ Usage: convert [-himpv] [-d delimiter] [-n identifier] [-o output_file] -f forma
   -n LDAP identifier added to dn:
   -o Output file (write to stdout by default)
   -d CSV col delimiter
+  -e EOL marker (unix,dos,mac, default unix)
   -h Include header line in CSV output
   -i Convert CSV output to ISO-8859-1 encoding
   -m Only convert cards with an e-mail address
@@ -105,7 +106,16 @@ if ($conv->fromFile($file))
 		else if ($format == 'csv')
 		{
 			$delimiter = $opt['d'] ? ($opt['d']=='\t' || $opt['d']=='tab' ? "\t" : $opt['d']) : ";";
-			$out = $conv->toCSV($delimiter, isset($opt['h']), isset($opt['i']) ? 'ISO-8859-1' : null);
+			$eol_marker = array(
+				'unix' => "\n",
+				'dos' => "\r\n",
+				'mac' => "\r",
+			);
+			if ($opt['e'] && array_key_exists($opt['e'], $eol_marker)) 
+				$eol_marker = $eol_marker[$opt['d']];
+			else
+				$eol_marker = "\n";
+			$out = $conv->toCSV($delimiter, "\n", isset($opt['h']), isset($opt['i']) ? 'ISO-8859-1' : null);
 			
 			if (isset($opt['v']) && isset($opt['i']))
 				echo "Converting output to ISO-8859-1\n";


### PR DESCRIPTION
MS Outlook (at least of Office 2010; I can't test with other versions) cannot import multiple contacts from vcf files; it has however csv import. The csv import requires dos-style line endings, so first I added the option to change the line ending style from the default (unix) to dos and old-style mac.
Additionally, the german outlook requires german csv headers to get the field associations right automatically, so I added a special option for the correct headers, so files converted with this option can be imported with manual field rewiring (this can for sure also be done for the english or other language versions).
I also found a small bug (. instead of ;) that duplicated a lot of the csv headers.
