### PR TITLE
Use MD5 to match image file names with exported csv records

### DIFF
--- a/vcard_convert.php
+++ b/vcard_convert.php
@@ -283,7 +283,8 @@ class vcard_convert extends Contact_Vcard_Parse
 				$vcard->im['jabber'] = $card['X-JABBER'][0]['value'][0][0];
 
 			if (is_array($card['PHOTO'][0]))
-				$vcard->photo = array('data' => $card['PHOTO'][0]['value'][0][0], 'encoding' => $card['PHOTO'][0]['param']['ENCODING'][0], 'type' => $card['PHOTO'][0]['param']['TYPE'][0]);
+				$vcard->photo = array('data' => $card['PHOTO'][0]['value'][0][0], 'encoding' => $card['PHOTO'][0]['param']['ENCODING'][0], 'type' => $card['PHOTO'][0]['param']['TYPE'][0], 
+				'md5' => md5($card['PHOTO'][0]['value'][0][0]));
 
 			$vcard->categories = join(',', (array)$card['CATEGORIES'][0]['value'][0]);
 
@@ -927,7 +928,8 @@ class vcard_convert extends Contact_Vcard_Parse
 					// A FIX: Since some cards may give no (or identical) filenames
 					// after the cleanup by asciiwords, always generate a random UID
 					// for card's file name
-					$fn = asciiwords(strtolower($card->displayname));
+					// MD5 is added to enable matching the image file name with exported csv records
+					$fn = asciiwords(strtolower($card->displayname)).'-md5-'.$card->photo['md5'];
 					if (empty($fn) || preg_match("/^[_ -]+$/",$fn) || preg_match("/^-/",$fn))
 						$fn = uniqid('card-id-');
 					else


### PR DESCRIPTION
This PR is work in progress.  I will complete it if you think it's worthy and if you give me directions.  See this PR's discussion for details.

Is it worth doing?  I think so.  This is the problem I need to solve: matching exported image file names with their corresponding exported csv record.

**My analysis of the master version** -- The image file name consists of the name+surname, which isn't unique, and a random unique id, which can't be matched with any csv record. The latter happens because 1) records don't include such ids, and 2) the unique id is randomly generated when the image is exported, which happens separately from csv export.  Feel free to correct my analysis.

So, in order to match an image with its record, we need an image id that can be generated consistently when image exporting and csv exporting take place separately.  Alternatively, we need to export the csv and the img formats in a single run, and save the current uniqid in the csv record.  My preference is to get rid of the uniqid altogether, because it's random, and replace it with md5, because it can be consistently generated in the same run or even in separate runs.

**What's missing in the current PR** --  Apart from deleting lines 933-936, I need to know from you how to add a new csv column that holds the md5 of card->photo data.  Moreover, what should the new csv column's name?  Finally,  I'm not familiar with the other formats, ldif, fritzbox, etc. so I don't know if an md5 should or even could be added to such export formats.

In conclusion, are you interested in this feature, would you do it with an md5, and can you tell me where/what to change to add the new csv column?  I won't be offended if you prefer to make the changes yourself :)