### PR TITLE
Fix options in shebang line and updated rune access for PHP 7.4+

### DIFF
--- a/vcfconvert.sh
+++ b/vcfconvert.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env php -qC 
+#!/usr/bin/env -S php -qC 
 <?php
 
 /*
@@ -36,7 +36,7 @@ function get_args()
 			for ($j=1; $j < strlen($arg); $j++)
 			{
 				$key = $arg[$j];
-				$value = $_SERVER['argv'][$i+1]{0} != '-' ? preg_replace(array('/^["\']/', '/["\']$/'), '', $_SERVER['argv'][++$i]) : true;
+				$value = $_SERVER['argv'][$i+1][0] != '-' ? preg_replace(array('/^["\']/', '/["\']$/'), '', $_SERVER['argv'][++$i]) : true;
 				$args[$key] = $value;
 			}
 		}


### PR DESCRIPTION
First line requires `-S` if we want to pass a binary with options, tried in bash and fish:

```sh
❯ ./vcfconvert.sh -f csv -d "," -o contacts.csv ../Downloads/contacts.vcf
/usr/bin/env: ‘php -qC’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```

The curly braces to access a rune is no longer supported:

```sh
❯ ./vcfconvert.sh -f csv -d "," -o contacts.csv ../Downloads/contacts.vcf
PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in /home/seraf/vcfconvert/vcfconvert.sh on line 39
```